### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,9 +1,9 @@
 # Datatypes
 
-SlowPWM  KEYWORD1
+SlowPWM	KEYWORD1
 
 # Methods and Functions
 
-on       KEYWORD2
-off      KEYWORD2
-update   KEYWORD2
+on	KEYWORD2
+off	KEYWORD2
+update	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords